### PR TITLE
Update SDK and add backing for confirmAllAssigments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/react-native-superwall/releases) on GitHub.
 
+## 1.3.3
+
+### Enhancements
+
+- Upgrades Android SDK to 1.3.0 [View Android SDK release notes](https://github.com/superwall-me/Superwall-Android/releases/tag/1.3.0)
+- Upgrades iOS SDK to 3.10.1 [View iOS SDK release notes](https://github.com/superwall-me/Superwall-iOS/releases/tag/3.10.1)
+- Adds `passIdentifiersToPlayStore` to `SuperwallOptions` which allows you to pass user identifiers to the Play Store purchases as account identifiers. This is useful for tracking user purchases in the Play Store console.
+- Adds `confirmAllAssignments` method to `Superwall` which confirms assignments for all placements and returns an array of all confirmed experiment assignments. Note that the assignments may be different when a placement is registered due to changes in user, placement, or device parameters used in audience filters.
+
 ## 1.3.2
 
 ### Enhancements

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -91,6 +91,6 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation "com.superwall.sdk:superwall-android:1.2.9"
+  implementation "com.superwall.sdk:superwall-android:1.3.0"
   implementation 'com.android.billingclient:billing:6.1.0'
 }

--- a/android/src/main/java/com/superwallreactnative/SuperwallReactNativeModule.kt
+++ b/android/src/main/java/com/superwallreactnative/SuperwallReactNativeModule.kt
@@ -237,4 +237,18 @@ class SuperwallReactNativeModule(private val reactContext: ReactApplicationConte
       promise.resolve(null)
     }
   }
+
+  @ReactMethod
+  fun confirmAllAssignments(promise: Promise) {
+    CoroutineScope(Dispatchers.IO).launch {
+      val result = Superwall.instance.confirmAllAssignments()
+      val array = Arguments.createArray()
+      result.forEach { assignment ->
+        array.pushMap(assignment.toJson())
+      }
+      launch(Dispatchers.Main) {
+        promise.resolve(array)
+      }
+    }
+  }
 }

--- a/android/src/main/java/com/superwallreactnative/models/ConfirmedAssignments.kt
+++ b/android/src/main/java/com/superwallreactnative/models/ConfirmedAssignments.kt
@@ -1,0 +1,13 @@
+package com.superwallreactnative.models
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReadableMap
+
+import com.superwall.sdk.models.triggers.Experiment
+import com.superwall.sdk.models.assignment.ConfirmedAssignment
+
+fun ConfirmedAssignment.toJson(): ReadableMap {
+    val assignmentMap = Arguments.createMap()
+    assignmentMap.putString("experimentId", this.experimentId)
+    assignmentMap.putString("variant", this.variant.type.toString())
+    return assignmentMap
+}

--- a/android/src/main/java/com/superwallreactnative/models/SuperwallEvent.kt
+++ b/android/src/main/java/com/superwallreactnative/models/SuperwallEvent.kt
@@ -196,6 +196,9 @@ class SuperwallEvent {
         is SuperwallEvent.ConfigFail -> {
           map.putString("event", "configFail")
         }
+        is SuperwallEvent.ConfirmAllAssignments -> {
+          map.putString("event", "confirmAllAssignments")
+        }
       }
       return map
     }

--- a/android/src/main/java/com/superwallreactnative/models/SuperwallOptions.kt
+++ b/android/src/main/java/com/superwallreactnative/models/SuperwallOptions.kt
@@ -14,6 +14,7 @@ class SuperwallOptions {
       options.localeIdentifier = json.getString("localeIdentifier")
       options.isExternalDataCollectionEnabled = json.getBoolean("isExternalDataCollectionEnabled")
       options.isGameControllerEnabled = json.getBoolean("isGameControllerEnabled")
+      options.passIdentifiersToPlayStore = json.getBoolean("passIdentifiersToPlayStore")
 
       val networkEnvironment = when (json.getString("networkEnvironment")) {
         "release" -> SuperwallOptions.NetworkEnvironment.Release()

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1122,8 +1122,8 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-    - SuperwallKit (= 3.10.0)
-  - SuperwallKit (3.10.0)
+    - SuperwallKit (= 3.10.1)
+  - SuperwallKit (3.10.1)
   - Yoga (1.14.0)
 
 DEPENDENCIES:

--- a/ios/Json/ConfirmedAssignments+Json.swift
+++ b/ios/Json/ConfirmedAssignments+Json.swift
@@ -1,0 +1,21 @@
+import Foundation
+import SuperwallKit
+
+extension ConfirmedAssignment {
+    func toJson() -> [String: Any] {
+        return [
+            "experimentId": experimentId,
+            "variant": variant.type.rawValue
+        ]
+    }
+    
+    static func fromJson(_ json: [String: Any]) -> ConfirmedAssignment? {
+        guard let experimentId = json["experimentId"] as? Experiment.ID,
+              let variantTypeString = json["variant"] as? String,
+              let variantType = Experiment.Variant.VariantType(rawValue: variantTypeString) else {
+            return nil
+        }
+        let variant = Experiment.Variant(id: "", type: variantType, paywallId: nil)
+        return ConfirmedAssignment(experimentId: experimentId, variant: variant)
+    }
+}

--- a/ios/SuperwallReactNative.mm
+++ b/ios/SuperwallReactNative.mm
@@ -62,6 +62,11 @@ RCT_EXTERN_METHOD(
   withRejecter:(RCTPromiseRejectBlock)reject
 )
 
+RCT_EXTERN_METHOD(
+  confirmAllAssignments:(RCTPromiseResolveBlock)resolve
+  withRejecter:(RCTPromiseRejectBlock)reject
+)
+
 + (BOOL)requiresMainQueueSetup
 {
   return NO;

--- a/ios/SuperwallReactNative.swift
+++ b/ios/SuperwallReactNative.swift
@@ -214,4 +214,14 @@ class SuperwallReactNative: RCTEventEmitter {
       resolve(nil)
     }
   }
+
+  @objc(confirmAllAssignments:withRejecter:)
+  func confirmAllAssignments(
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+      Superwall.shared.confirmAllAssignments() { assignments in
+        resolve(assignments.map { $0.toJson() })
+      }
+  }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,7 @@ import { NativeEventEmitter } from 'react-native';
 import { IdentityOptions } from './public/IdentityOptions';
 import { EventEmitter } from 'events';
 import { ConfigurationStatus } from './public/ConfigurationStatus';
+import { ConfirmedAssignment } from './public/ConfirmedAssigments';
 const { version } = require('../package.json');
 
 const LINKING_ERROR =
@@ -319,9 +320,17 @@ export default class Superwall {
     );
   }
 
+  async confirmAllAssignments(): Promise<ConfirmedAssignment[]> {
+    await this.awaitConfig();
+    const assignments = await SuperwallReactNative.confirmAllAssignments();
+    return assignments.map((assignment: any) =>
+      ConfirmedAssignment.fromJson(assignment)
+    );
+  }
+
   async getConfigurationStatus(): Promise<ConfigurationStatus> {
     const configurationStatusString =
-      await SuperwallReactNative.getConfigurationStatus();
+      await SuperwallReactNative.confirmAllAssignments();
     return ConfigurationStatus.fromString(configurationStatusString);
   }
 

--- a/src/public/ConfirmedAssigments.ts
+++ b/src/public/ConfirmedAssigments.ts
@@ -1,0 +1,18 @@
+import { VariantType } from './Experiment';
+
+export class ConfirmedAssignment {
+  experimentId: String;
+  variant: VariantType;
+
+  constructor(experimentId: String, variant: VariantType) {
+    this.experimentId = experimentId;
+    this.variant = variant;
+  }
+
+  static fromJson(json: any): ConfirmedAssignment {
+    return new ConfirmedAssignment(
+      json.experimentId,
+      VariantType[json.variant as keyof typeof VariantType]
+    );
+  }
+}

--- a/src/public/SuperwallOptions.ts
+++ b/src/public/SuperwallOptions.ts
@@ -28,6 +28,7 @@ export class SuperwallOptions {
   isGameControllerEnabled: boolean = false;
   logging: LoggingOptions = new LoggingOptions();
   collectAdServicesAttribution: boolean = false;
+  passIdentifiersToPlayStore: boolean = false;
 
   // Optionally, add a constructor for customization or methods for manipulation
   constructor(init?: Partial<SuperwallOptions>) {
@@ -47,6 +48,7 @@ export class SuperwallOptions {
       isGameControllerEnabled: this.isGameControllerEnabled,
       logging: this.logging.toJson(),
       collectAdServicesAttribution: this.collectAdServicesAttribution,
+      passIdentifiersToPlayStore: this.passIdentifiersToPlayStore,
     };
   }
 }

--- a/superwall-react-native.podspec
+++ b/superwall-react-native.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/superwall-me/Superwall-React-Native.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "SuperwallKit", '3.10.0'
+  s.dependency "SuperwallKit", '3.10.1'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
## 1.3.3

### Enhancements

- Upgrades Android SDK to 1.3.0 [View Android SDK release notes](https://github.com/superwall-me/Superwall-Android/releases/tag/1.3.0)
- Upgrades iOS SDK to 3.10.1 [View iOS SDK release notes](https://github.com/superwall-me/Superwall-iOS/releases/tag/3.10.1)
- Adds `passIdentifiersToPlayStore` to `SuperwallOptions` which allows you to pass user identifiers to the Play Store purchases as account identifiers. This is useful for tracking user purchases in the Play Store console.
- Adds `confirmAllAssignments` method to `Superwall` which confirms assignments for all placements and returns an array of all confirmed experiment assignments. Note that the assignments may be different when a placement is registered due to changes in user, placement, or device parameters used in audience filters.
