### PR TITLE
1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 ### Enhancements
 
 - Upgrades Android SDK to 1.3.1 [View Android SDK release notes](https://github.com/superwall-me/Superwall-Android/releases/tag/1.3.1)
+- Upgrades iOS SDK to 3.11.1 [View iOS SDK release notes](https://github.com/superwall-me/Superwall-iOS/releases/tag/3.11.1)
 - Adds `preloadAllPaywalls` and `preloadPaywalls(eventNames: Set<String>)` method to `Superwall` which preloads all paywalls or paywalls for the event names passed in the argument.
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/react-native-superwall/releases) on GitHub.
 
+## 1.3.4
+
+### Enhancements
+
+- Upgrades Android SDK to 1.3.1 [View Android SDK release notes](https://github.com/superwall-me/Superwall-Android/releases/tag/1.3.1)
+- Adds `preloadAllPaywalls` and `preloadPaywalls(eventNames: Set<String>)` method to `Superwall` which preloads all paywalls or paywalls for the event names passed in the argument.
+
+### Fixes
+
+- Fixes issue with the `Experiment` inside `PaywallInfo` being `null` in the `handleSuperwallEvent` delegate for iOS.
+
 ## 1.3.3
 
 ### Enhancements

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -91,6 +91,6 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation "com.superwall.sdk:superwall-android:1.3.0"
+  implementation "com.superwall.sdk:superwall-android:1.3.1"
   implementation 'com.android.billingclient:billing:6.1.0'
 }

--- a/android/src/main/java/com/superwallreactnative/SuperwallReactNativeModule.kt
+++ b/android/src/main/java/com/superwallreactnative/SuperwallReactNativeModule.kt
@@ -7,6 +7,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.superwall.sdk.Superwall
 import com.superwall.sdk.identity.identify
@@ -250,5 +251,17 @@ class SuperwallReactNativeModule(private val reactContext: ReactApplicationConte
         promise.resolve(array)
       }
     }
+  }
+
+  @ReactMethod
+  fun preloadPaywalls(eventNames: ReadableArray) {
+    val eventNames = eventNames.toArrayList().toSet() as Set<String>
+    Superwall.instance.preloadPaywalls(eventNames)
+  }
+
+  @ReactMethod
+  fun preloadAllPaywalls(promise: Promise) {
+    Superwall.instance.preloadAllPaywalls()
+    promise.resolve(null)
   }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1118,12 +1118,14 @@ PODS:
     - PurchasesHybridCommon (= 9.7.2)
     - React-Core
   - SocketRocket (0.6.1)
-  - superwall-react-native (1.3.2):
+  - Superscript (0.1.12)
+  - superwall-react-native (1.3.4):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-    - SuperwallKit (= 3.10.1)
-  - SuperwallKit (3.10.1)
+    - SuperwallKit (= 3.11.1)
+  - SuperwallKit (3.11.1):
+    - Superscript (= 0.1.12)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -1220,6 +1222,7 @@ SPEC REPOS:
     - PurchasesHybridCommon
     - RevenueCat
     - SocketRocket
+    - Superscript
     - SuperwallKit
 
 EXTERNAL SOURCES:
@@ -1389,8 +1392,9 @@ SPEC CHECKSUMS:
   RevenueCat: 7be0d7bde9efb2fc1ebd1888522c55bb4f9feb18
   RNPurchases: 06957eb2f35bd7bb336d32fccf3534d45a3fda8a
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  superwall-react-native: 9092fa4e0d385c480e835a032132b46a3c13b2bc
-  SuperwallKit: 89cfaba57c139f97a578efc6bbb1f3963d2aa6b2
+  Superscript: 1ed1b4364f93bd16be05d085bba7357dbab95c83
+  superwall-react-native: be4cd6ea0670a4f2f08986309a7ca27ee5f0e684
+  SuperwallKit: ff739c94ebc351ae210c8b0f0b3931e930d74053
   Yoga: 1b901a6d6eeba4e8a2e8f308f708691cdb5db312
 
 PODFILE CHECKSUM: 76fced934770e056b70a3087a2bc377b3556bae1

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { StyleSheet, View, Platform, Button, Linking } from 'react-native';
-import Superwall, { SuperwallOptions } from '@superwall/react-native-superwall';
+import Superwall from '@superwall/react-native-superwall';
 import { RCPurchaseController } from './RCPurchaseController';
 import { MySuperwallDelegate } from './MySuperwallDelegate';
 

--- a/ios/SuperwallReactNative.mm
+++ b/ios/SuperwallReactNative.mm
@@ -67,6 +67,10 @@ RCT_EXTERN_METHOD(
   withRejecter:(RCTPromiseRejectBlock)reject
 )
 
+RCT_EXTERN_METHOD(preloadAllPaywalls)
+
+RCT_EXTERN_METHOD(preloadPaywalls:(NSArray<NSString *> *)eventNames)
+
 + (BOOL)requiresMainQueueSetup
 {
   return NO;

--- a/ios/SuperwallReactNative.swift
+++ b/ios/SuperwallReactNative.swift
@@ -228,4 +228,18 @@ class SuperwallReactNative: RCTEventEmitter {
       resolve(assignments.map { $0.toJson() })
     }
   }
+
+  @objc(preloadPaywalls:)
+  func preloadPaywalls(eventNames: [String]) {
+    Superwall.shared.preloadPaywalls(eventNames)
+  }
+
+  @objc(preloadAllPaywalls:withRejecter:)
+  func preloadAllPaywalls(
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    Superwall.shared.preloadAllPaywalls()
+    resolve(nil)
+  }
 }

--- a/ios/SuperwallReactNative.swift
+++ b/ios/SuperwallReactNative.swift
@@ -230,16 +230,12 @@ class SuperwallReactNative: RCTEventEmitter {
   }
 
   @objc(preloadPaywalls:)
-  func preloadPaywalls(eventNames: [String]) {
-    Superwall.shared.preloadPaywalls(eventNames)
+  func preloadPaywalls(forEvents eventNames: [String]) {
+    Superwall.shared.preloadPaywalls(forEvents: Set(eventNames))
   }
 
-  @objc(preloadAllPaywalls:withRejecter:)
-  func preloadAllPaywalls(
-    resolve: @escaping RCTPromiseResolveBlock,
-    reject: @escaping RCTPromiseRejectBlock
-  ) {
+  @objc(preloadAllPaywalls)
+  func preloadAllPaywalls() {
     Superwall.shared.preloadAllPaywalls()
-    resolve(nil)
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superwall/react-native-superwall",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "The React Native package for Superwall",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -359,6 +359,16 @@ export default class Superwall {
     return userAttributes;
   }
 
+  async preloadAllPaywalls() {
+    await this.awaitConfig();
+    await SuperwallReactNative.preloadAllPaywalls();
+  }
+
+  async preloadPaywalls(eventNames: Set<string>) {
+    await this.awaitConfig();
+    await SuperwallReactNative.preloadPaywalls(eventNames);
+  }
+
   async setUserAttributes(userAttributes: UserAttributes) {
     await this.awaitConfig();
     await SuperwallReactNative.setUserAttributes(userAttributes);

--- a/superwall-react-native.podspec
+++ b/superwall-react-native.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/superwall-me/Superwall-React-Native.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "SuperwallKit", '3.10.1'
+  s.dependency "SuperwallKit", '3.11.1'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
## 1.3.4

### Enhancements

- Upgrades Android SDK to 1.3.1 [View Android SDK release notes](https://github.com/superwall-me/Superwall-Android/releases/tag/1.3.1)
- Upgrades iOS SDK to 3.11.1 [View iOS SDK release notes](https://github.com/superwall-me/Superwall-iOS/releases/tag/3.11.1)
- Adds `preloadAllPaywalls` and `preloadPaywalls(eventNames: Set<String>)` method to `Superwall` which preloads all paywalls or paywalls for the event names passed in the argument.

### Fixes

- Fixes issue with the `Experiment` inside `PaywallInfo` being `null` in the `handleSuperwallEvent` delegate for iOS.

