### PR TITLE
2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/react-native-superwall/releases) on GitHub.
 
+## 2.0.2
+
+### Fixes
+
+- Readds `handleDeepLink(url:)` to `Superwall`.
+
 ## 2.0.1
 
 ### Fixes

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1161,7 +1161,7 @@ PODS:
     - React-Core
   - SocketRocket (0.6.1)
   - Superscript (0.1.17)
-  - superwall-react-native (2.0.1):
+  - superwall-react-native (2.0.2):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1459,7 +1459,7 @@ SPEC CHECKSUMS:
   RNVectorIcons: 36b9fb776f0d0722582af7c5cbde94a4157c6914
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Superscript: 9854c733dd673a2cbc5dd9f919bf31e2b50345b1
-  superwall-react-native: 3bac5e6ac1cddce1059840e1b76248be226d6f53
+  superwall-react-native: 0135b11bdd860934c1078df5e8fd78dafdf1b2fc
   SuperwallKit: 4ef491d2d0ad623b72d9525710cb42bf6147ccb2
   Yoga: 1b901a6d6eeba4e8a2e8f308f708691cdb5db312
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Platform, Linking } from 'react-native';
-import Superwall from '@superwall/react-native-superwall';
+import Superwall from '../../src';
 import { RCPurchaseController } from './RCPurchaseController';
 import { MySuperwallDelegate } from './MySuperwallDelegate';
 import { NavigationContainer } from '@react-navigation/native';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superwall/react-native-superwall",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "The React Native package for Superwall",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -358,6 +358,17 @@ export default class Superwall {
   }
 
   /**
+   * Handles a deep link.
+   *
+   * @param {string} url - The deep link to handle.
+   * @returns {Promise<Boolean>} A promise that resolves to a boolean indicating whether the deep link was handled.
+   */
+  async handleDeepLink(url: string): Promise<Boolean> {
+    await this.awaitConfig();
+    return await SuperwallReactNative.handleDeepLink(url);
+  }
+
+  /**
    * Registers a placement to access a feature.
    *
    * When the placement is added to a campaign on the [Superwall Dashboard](https://superwall.com/dashboard),


### PR DESCRIPTION
### Fixes

- Readds `handleDeepLink(url:)` to `Superwall` as mentioned here: #49 