### PR TITLE
2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/react-native-superwall/releases) on GitHub.
 
+## 2.0.5
+
+### Enhancements
+
+- Upgrades Android SDK to 2.0.2 [View iOS SDK release notes](https://github.com/superwall/Superwall-Android/releases/tag/2.0.2).
+
 ## 2.0.4
 
 ### Enhancements

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -91,6 +91,6 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation "com.superwall.sdk:superwall-android:2.0.1"
+  implementation "com.superwall.sdk:superwall-android:2.0.2"
   implementation 'com.android.billingclient:billing:6.1.0'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superwall/react-native-superwall",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "The React Native package for Superwall",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Changes in this pull request

### Enhancements

- Upgrades Android SDK to 2.0.2 [View iOS SDK release notes](https://github.com/superwall/Superwall-Android/releases/tag/2.0.2).

### Checklist

- [ ] I updated the version number.
- [ ] I ran `pod install` on the iOS example project, which builds and runs.
- [ ] Android example project builds and runs.
- [ ] Expo example project builds and runs.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/react-native-superwall/blob/main/CONTRIBUTING.md)
