### PR TITLE
 Kotlin Compilation Errors on Android with Superwall SDK v2.0.9

### DIFF
--- a/android/src/main/java/com/superwallreactnative/SuperwallReactNativeModule.kt
+++ b/android/src/main/java/com/superwallreactnative/SuperwallReactNativeModule.kt
@@ -159,7 +159,7 @@ class SuperwallReactNativeModule(private val reactContext: ReactApplicationConte
 
     Superwall.instance.register(
       placement = event,
-      params = params?.toHashMap(),
+      params = params?.toHashMap() as? Map<String, Any>,
       handler = handler,
       feature = {
         feature?.resolve(null)
@@ -338,13 +338,15 @@ class SuperwallReactNativeModule(private val reactContext: ReactApplicationConte
     promise: Promise
   ) {
     CoroutineScope(Dispatchers.IO).launch {
-      Superwall.instance.getPresentationResult(event, params?.toHashMap()).fold({
-        launch(Dispatchers.Main) {
-          promise.resolve(it.toJson())
-        }
-      },{
-        promise.reject("Error", it.message)
-      })
+      // TODO: Superwall.instance.getPresentationResult is internal. Find a public API alternative.
+      promise.reject("NotImplemented", "getPresentationResult is currently not available on Android.")
+      // Superwall.instance.getPresentationResult(event, params?.toHashMap()).fold({
+      //   launch(Dispatchers.Main) {
+      //     promise.resolve(it.toJson())
+      //   }
+      // }, {
+      //   promise.reject("Error", it.message)
+      // })
     }
   }
 

--- a/android/src/main/java/com/superwallreactnative/models/SuperwallOptions.kt
+++ b/android/src/main/java/com/superwallreactnative/models/SuperwallOptions.kt
@@ -32,9 +32,11 @@ class SuperwallOptions {
       if (scopesArray != null) {
         for (i in 0 until scopesArray.size()) {
           val scopeStr = scopesArray.getString(i)
-          try {
-            scopes.add(enumValueOf<LogScope>(scopeStr))
-          } catch (e: IllegalArgumentException) {}
+          if (scopeStr != null) {
+            try {
+              scopes.add(enumValueOf<LogScope>(scopeStr))
+            } catch (e: IllegalArgumentException) {}
+          }
         }
       }
 


### PR DESCRIPTION
issue : [#73]

## Changes in this pull request

- Fixed several Kotlin compile errors in the Android native module:
    - Resolved type mismatch error in `SuperwallReactNativeModule.kt:162` by casting `params` to `Map<String, Any>?`.
    - Temporarily addressed `internal` access and unresolved reference errors related to `getPresentationResult` in `SuperwallReactNativeModule.kt:341` by commenting out the call and adding a `NotImplemented` rejection. A public API alternative should be investigated.
    - Fixed a potential NullPointerException in `SuperwallOptions.kt:36` by adding a null check for `scopeStr` before using it.

### Checklist

- [ ] I updated the version number.
- [ ] I ran `pod install` on the iOS example project, which builds and runs.
- [ ] Android example project builds and runs.
- [ ] Expo example project builds and runs.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/react-native-superwall/blob/main/CONTRIBUTING.md)