### PR TITLE
Fix iOS restore purchase error state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/react-native-superwall/releases) on GitHub.
 
+## 2.0.11
+
+### Enhancements
+
+- Upgrades iOS SDK to 4.2.0 [View iOS SDK release notes](https://github.com/superwall/Superwall-iOS/releases/tag/4.2.0).
+
+### Fixes
+
+- Fixes an issue preventing `RestorationResult.failed` from deserializing, which caused failed Restore Purchases attempts to get stuck with the loading indicator shown.
+
 ## 2.0.10
 
 ### Enhancements

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1160,14 +1160,14 @@ PODS:
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
   - SocketRocket (0.6.1)
-  - Superscript (0.1.18)
-  - superwall-react-native (2.0.10):
+  - Superscript (0.2.4)
+  - superwall-react-native (2.0.11):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-    - SuperwallKit (= 4.0.6)
-  - SuperwallKit (4.0.6):
-    - Superscript (= 0.1.18)
+    - SuperwallKit (= 4.2.0)
+  - SuperwallKit (4.2.0):
+    - Superscript (= 0.2.4)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -1408,61 +1408,61 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   PurchasesHybridCommon: 9691d74a051f30858360d78936d59dc14575014e
-  RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
+  RCT-Folly: cd21f1661364f975ae76b3308167ad66b09f53f5
   RCTRequired: ab7f915c15569f04a49669e573e6e319a53f9faa
   RCTTypeSafety: 63b97ced7b766865057e7154db0e81ce4ee6cf1e
   React: 1c87497e50fa40ba9c54e5ea5e53483a0f8eecc0
   React-callinvoker: e3a52a9a93e3eb004d7282c26a4fb27003273fe6
-  React-Codegen: 50c0f8f073e71b929b057b68bf31be604f1dccc8
-  React-Core: d0ecde72894b792cb8922efaa0990199cbe85169
-  React-CoreModules: 2ff1684dd517f0c441495d90a704d499f05e9d0a
-  React-cxxreact: d9be2fac926741052395da0a6d0bab8d71e2f297
+  React-Codegen: accd8617d26d9e8192f2105e2b715f346bbd6888
+  React-Core: e063354ccbed01b836af1e6e94b5cb8319097104
+  React-CoreModules: db63015ed3e85382f6d8ec7f78b5136cfb345c18
+  React-cxxreact: 7e569c1f7e4dda58ba17df36450c6d98df407b5b
   React-debug: 4678e73a37cb501d784e99ff0f219b4940362a3b
-  React-Fabric: 460ee9d4b8b9de3382504a711430bfead1d5be1e
-  React-FabricImage: d0a0631bc8ad9143f42bfccf9d3d533a144cc3d6
-  React-graphics: f0d5040263a9649e2a70ebe27b3120c49411afef
-  React-hermes: b9ac2f7b0c1eeb206eb883583cab7a973d570a6e
-  React-ImageManager: 6c4bf9d5ed363ead7b5aaf820a3feab221b7063e
-  React-jserrorhandler: 6e7a7e187583e14dc7a0053a2bdd66c252ea3b21
-  React-jsi: 380cd24dd81a705dd042c18989fb10b07182210c
-  React-jsiexecutor: 8ed7a18b9f119440efdcd424c8257dc7e18067e2
+  React-Fabric: a6a9148a530e4b5e984f5f3373b07ee0a2e41f45
+  React-FabricImage: 701972b5524a7a6a02710b55f0f6a82e94bd7da8
+  React-graphics: 46697b8481d17ead6e346f2cbdeee443eff3fd18
+  React-hermes: a29dacf053e80ebe20b680e30afe26580521e0c9
+  React-ImageManager: 9ae8207447796390d7b78beffd7aec8dc28311c4
+  React-jserrorhandler: e53f2eee7b67787ac8bfb6a709ac4eecdb57c2e9
+  React-jsi: 6db2f81ad41fc50394a70af6e38dd23ac483ff79
+  React-jsiexecutor: 951f2809bea7cab011dd1bbe06c631c75df4f673
   React-jsinspector: 9ac353eccf6ab54d1e0a33862ba91221d1e88460
-  React-logger: 0a57b68dd2aec7ff738195f081f0520724b35dab
-  React-Mapbuffer: 63913773ed7f96b814a2521e13e6d010282096ad
-  react-native-safe-area-context: b97eb6f9e3b7f437806c2ce5983f479f8eb5de4b
+  React-logger: 5295f5eac9d7624fe9a33a473442d8f4c1074197
+  React-Mapbuffer: f7ba4d5459e546d741791a55664388e97b31df7c
+  react-native-safe-area-context: 435f4c13ac75ceed6135382ee77d57d1a5b5b2d6
   React-nativeconfig: d7af5bae6da70fa15ce44f045621cf99ed24087c
-  React-NativeModulesApple: 0123905d5699853ac68519607555a9a4f5c7b3ac
+  React-NativeModulesApple: 7a561c2792b0a2b74aff6c58d2554dcf824372aa
   React-perflogger: 8a1e1af5733004bdd91258dcefbde21e0d1faccd
   React-RCTActionSheet: 64bbff3a3963664c2d0146f870fe8e0264aee4c4
-  React-RCTAnimation: b698168a7269265a4694727196484342d695f0c1
-  React-RCTAppDelegate: dcd8e955116eb1d1908dfaf08b4c970812e6a1e6
-  React-RCTBlob: 47f8c3b2b4b7fa2c5f19c43f0b7f77f57fb9d953
-  React-RCTFabric: 6067a32d683d0c2b84d444548bc15a263c64abed
-  React-RCTImage: ac0e77a44c290b20db783649b2b9cddc93e3eb99
-  React-RCTLinking: e626fd2900913fe5d25922ea1be394b7aafa09c9
-  React-RCTNetwork: d3114bce3977dafe8bd06421b29812f5a8527ba0
-  React-RCTSettings: a53511f90d8df637a1a11ac729179a4d2f734481
-  React-RCTText: f0176f5f5952f9a4a2c7354f5ae71f7c420aaf34
-  React-RCTVibration: 8160223c6eda5b187079fec204f80eca8b8f3177
-  React-rendererdebug: ed286b4da8648c27d6ed3ae1410d4b21ba890d5a
+  React-RCTAnimation: 548fdbd189275f721a4f3098da847a84e3e3339f
+  React-RCTAppDelegate: 7d6c7ca4a9d94c889533ad6730782f176ff4b43a
+  React-RCTBlob: 7bf2d87c667d5a570212d921583dca5e1156395c
+  React-RCTFabric: d3eee95226b91877334fefbbd4d48122f114506b
+  React-RCTImage: 8ad4a0f9e728ff81a229446a6a8de8657c133cc6
+  React-RCTLinking: 12c1070797c9242b8ca2d171fc43588de47e442d
+  React-RCTNetwork: 1a59d000d0053f56f405d52521ae9df1b6108aa3
+  React-RCTSettings: a3b91c385e2f3bc7aa2bae75b2f60c6fd0c9052e
+  React-RCTText: 78330d21c9d14d680f31a3a3866436b978a66a8c
+  React-RCTVibration: 632344d1fdb7f1d568d1c6715f2dfe270fff6e88
+  React-rendererdebug: 740d4bbbbea219809a58cde58c8af0e39c787831
   React-rncore: 43f133b89ac10c4b6ab43702a541dee1c292a3bf
   React-runtimeexecutor: e6ab6bb083dbdbdd489cff426ed0bce0652e6edf
-  React-runtimescheduler: ed48e5faac6751e66ee1261c4bd01643b436f112
-  React-utils: 6e5ad394416482ae21831050928ae27348f83487
-  ReactCommon: 840a955d37b7f3358554d819446bffcf624b2522
+  React-runtimescheduler: ceaeeb19e75912958625f72883d240640e8f40da
+  React-utils: 8439db27c3745f6de9d67eb61f5600c8d624274c
+  ReactCommon: cc18bd33c0fab03c67620da6a602dcc1704e66b4
   RevenueCat: e825836f5d6baa870c53d7281be25a5fd91abd91
-  RNCMaskedView: 1611be41c9f78f5ecbcff2360b0891593c1c0ce1
-  RNGestureHandler: 33d5ab6ef9016c112d135d7f17e2657ddf32f16c
-  RNPurchases: 3b35539c86769ad8a8f838060559cf13d0a8fcb1
-  RNReanimated: 69c281d0f6a57c22675914581b72ac67f294b0c2
-  RNScreens: 9e8dfa7786aee3750d2b9dae424f0f287632ca8c
-  RNVectorIcons: 48aa8b1a17c7f82461df43783b0818cad38a2bcf
+  RNCMaskedView: 1d506a5e6c2a15715b9e344694f404f526ec28d1
+  RNGestureHandler: c8dee734571c2ec651caab39597b9fddd5d883dc
+  RNPurchases: 2c8780f3b7be8af8cd6f3f3740ba4176465d1d0a
+  RNReanimated: 73b45aa4fd62e53e60e34889d7a76ef780542b39
+  RNScreens: 341431a90028837cd3cb58baef68efef21ee9b3b
+  RNVectorIcons: 36b9fb776f0d0722582af7c5cbde94a4157c6914
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Superscript: 88a0e5e467fc986289f99e20e383232513c41ea9
-  superwall-react-native: 90a318db56ce00d542e35710c5fbc46cc601f19a
-  SuperwallKit: 18a4588702d5369880563d5a17cb967423f94c89
+  Superscript: ede1cf73124c02ba1e120fbe5e15d3c4b12020a0
+  superwall-react-native: 7132ba877625ae2a231ee686bec1c8cb5ce6c120
+  SuperwallKit: 251deebb67abfea37c21f8439571658ae63cf3e4
   Yoga: 1b901a6d6eeba4e8a2e8f308f708691cdb5db312
 
 PODFILE CHECKSUM: 8af2b30826dbb5f7e846756dbe779b256a5b6e1a
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/ios/Json/RestorationResult+Json.swift
+++ b/ios/Json/RestorationResult+Json.swift
@@ -13,7 +13,7 @@ extension RestorationResult {
     case "restored":
       return RestorationResult.restored
     case "failed":
-      guard let message = dictionary["error"] as? String else {
+      guard let message = dictionary["errorMessage"] as? String else {
         return nil
       }
       return RestorationResult.failed(RestorationResultError(message: message))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superwall/react-native-superwall",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "The React Native package for Superwall",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/superwall-react-native.podspec
+++ b/superwall-react-native.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/superwall/Superwall-React-Native.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "SuperwallKit", '4.0.6'
+  s.dependency "SuperwallKit", '4.2.0'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
## Changes in this pull request

- Fixes an issue preventing `RestorationResult.failed` from deserializing, which caused failed Restore Purchases attempts to get stuck with the loading indicator shown

### Checklist

- [ ] I updated the version number.
- [X] I ran `pod install` on the iOS example project, which builds and runs.
- [X] Android example project builds and runs.
- [ ] Expo example project builds and runs.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [X] I have updated the SDK documentation as well as the online docs.
- [X] I have reviewed the [contributing guide](https://github.com/superwall/react-native-superwall/blob/main/CONTRIBUTING.md)
