### PR TITLE
2.1.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/react-native-superwall/releases) on GitHub.
 
+## 2.1.0 (Beta 2)
+
+### Fixes
+
+- Fixes an issue preventing `SuperwallDelegate.didRedeemLink` from getting called when a Web Checkout link was redeemed.
+
 ## 2.1.0 (Beta 1)
 
 ### Enhancements

--- a/ios/Bridges/SuperwallDelegateBridge.swift
+++ b/ios/Bridges/SuperwallDelegateBridge.swift
@@ -84,7 +84,7 @@ final class SuperwallDelegateBridge: SuperwallDelegate {
     sendEvent(withName: "willRedeemLink", body: [:])
   }
 
-  func didRedeemLink(withResult result: RedemptionResult) {
+  func didRedeemLink(result: RedemptionResult) {
     sendEvent(withName: "didRedeemLink", body: result.toJson())
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superwall/react-native-superwall",
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "description": "The React Native package for Superwall",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -256,7 +256,7 @@ export default class Superwall {
     });
 
     this.eventEmitter.addListener('didRedeemLink', async (data) => {
-      const result = RedemptionResults.fromJson(data.result);
+      const result = RedemptionResults.fromJson(data);
       Superwall.delegate?.didRedeemLink(result);
     });
   }


### PR DESCRIPTION
## Changes in this pull request

- Fixes an issue preventing `SuperwallDelegate.didRedeemLink` from getting called when a Web Checkout link was redeemed.

### Checklist

- [X] I updated the version number.
- [X] I ran `pod install` on the iOS example project, which builds and runs.
- [ ] Android example project builds and runs.
- [ ] Expo example project builds and runs.
- [X] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.
- [X] I have reviewed the [contributing guide](https://github.com/superwall/react-native-superwall/blob/main/CONTRIBUTING.md)
