### PR TITLE
feature: make the SuperwallDelegate a real class so we can extend onl…

### DIFF
--- a/src/public/SuperwallDelegate.ts
+++ b/src/public/SuperwallDelegate.ts
@@ -1,28 +1,30 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// @ts-nocheck TS6133: Unused variable
 import { PaywallInfo } from './PaywallInfo';
 import type { RedemptionResult } from './RedemptionResults';
 import { SubscriptionStatus } from './SubscriptionStatus';
 import { SuperwallEventInfo } from './SuperwallEventInfo';
 
-export abstract class SuperwallDelegate {
-  abstract subscriptionStatusDidChange(
+export class SuperwallDelegate {
+  subscriptionStatusDidChange(
     from: SubscriptionStatus,
     to: SubscriptionStatus
-  ): void;
-  abstract willRedeemLink(): void;
-  abstract didRedeemLink(result: RedemptionResult): void;
-  abstract handleSuperwallEvent(eventInfo: SuperwallEventInfo): void;
-  abstract handleCustomPaywallAction(name: string): void;
-  abstract willDismissPaywall(paywallInfo: PaywallInfo): void;
-  abstract willPresentPaywall(paywallInfo: PaywallInfo): void;
-  abstract didDismissPaywall(paywallInfo: PaywallInfo): void;
-  abstract didPresentPaywall(paywallInfo: PaywallInfo): void;
-  abstract paywallWillOpenURL(url: URL): void;
-  abstract paywallWillOpenDeepLink(url: URL): void;
-  abstract handleLog(
+  ): void {}
+  willRedeemLink(): void {}
+  didRedeemLink(result: RedemptionResult): void {}
+  handleSuperwallEvent(eventInfo: SuperwallEventInfo): void {}
+  handleCustomPaywallAction(name: string): void {}
+  willDismissPaywall(paywallInfo: PaywallInfo): void {}
+  willPresentPaywall(paywallInfo: PaywallInfo): void {}
+  didDismissPaywall(paywallInfo: PaywallInfo): void {}
+  didPresentPaywall(paywallInfo: PaywallInfo): void {}
+  paywallWillOpenURL(url: URL): void {}
+  paywallWillOpenDeepLink(url: URL): void {}
+  handleLog(
     level: string,
     scope: string,
     message?: string,
     info?: Map<string, any>,
     error?: string
-  ): void;
+  ): void {}
 }


### PR DESCRIPTION
## Changes in this pull request

- When implementing a `SuperwallDelegate` we face this error if we don't implement all the members 
![CleanShot 2025-06-09 at 16 34 52@2x](https://github.com/user-attachments/assets/dcefb803-bb6b-4ba8-99a7-a089725dc386)
- Most example in [this doc](https://superwall.com/docs/using-superwall-delegate) generate TS errors, this PR would fix it by adding an empty function for each method.


### Checklist

- [ ] I updated the version number.
- [ ] I ran `pod install` on the iOS example project, which builds and runs.
- [ ] Android example project builds and runs.
- [ ] Expo example project builds and runs.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall/react-native-superwall/blob/main/CONTRIBUTING.md)
